### PR TITLE
Added --min_tier: specify the minimum tier

### DIFF
--- a/protonvpn_cli/cli.py
+++ b/protonvpn_cli/cli.py
@@ -5,11 +5,14 @@ Usage:
     protonvpn init
     protonvpn (c | connect) [<servername>] [-p <protocol>]
     protonvpn (c | connect) [-f | --fastest] [-p <protocol>]
+        [--min_tier <min_tier>]
     protonvpn (c | connect) [--cc <code>] [-p <protocol>]
+        [--min_tier <min_tier>]
     protonvpn (c | connect) [--sc] [-p <protocol>]
-    protonvpn (c | connect) [--p2p] [-p <protocol>]
+    protonvpn (c | connect) [--p2p] [-p <protocol>] [--min_tier <min_tier>]
     protonvpn (c | connect) [--tor] [-p <protocol>]
     protonvpn (c | connect) [-r | --random] [-p <protocol>]
+        [--min_tier <min_tier>]
     protonvpn (r | reconnect)
     protonvpn (d | disconnect)
     protonvpn (s | status)
@@ -21,6 +24,8 @@ Usage:
 
 Options:
     -f, --fastest       Select the fastest ProtonVPN server.
+    --min_tier TIER     Minimum tier of the ProtonVPN server, 1-4.
+                        Must be compatible with your plan.
     -r, --random        Select a random ProtonVPN server.
     --cc CODE           Determine the country for fastest connect.
     --sc                Connect to the fastest Secure-Core server.
@@ -110,17 +115,22 @@ def cli():
         if protocol is not None and protocol.lower().strip() in ["tcp", "udp"]:
             protocol = protocol.lower().strip()
 
+        min_tier = args.get("--min_tier")
+        if min_tier is not None:
+            # Accept 1-based UI tier as input and set 0-based API tier
+            min_tier = int(min_tier) - 1
+
         if args.get("--random"):
-            connection.random_c(protocol)
+            connection.random_c(protocol, min_tier)
         elif args.get("--fastest"):
-            connection.fastest(protocol)
+            connection.fastest(protocol, min_tier)
         elif args.get("<servername>"):
             connection.direct(args.get("<servername>"), protocol)
         elif args.get("--cc") is not None:
-            connection.country_f(args.get("--cc"), protocol)
+            connection.country_f(args.get("--cc"), protocol, min_tier)
         # Features: 1: Secure-Core, 2: Tor, 4: P2P
         elif args.get("--p2p"):
-            connection.feature_f(4, protocol)
+            connection.feature_f(4, protocol, min_tier)
         elif args.get("--sc"):
             connection.feature_f(1, protocol)
         elif args.get("--tor"):

--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -123,7 +123,7 @@ def dialog():
     openvpn_connect(server_result, protocol_result)
 
 
-def random_c(protocol=None):
+def random_c(protocol=None, min_tier=None):
     """Connect to a random ProtonVPN Server."""
 
     logger.debug("Starting random connect")
@@ -131,14 +131,14 @@ def random_c(protocol=None):
     if not protocol:
         protocol = get_config_value("USER", "default_protocol")
 
-    servers = get_servers()
+    servers = get_servers(min_tier)
 
     servername = random.choice(servers)["Name"]
 
     openvpn_connect(servername, protocol)
 
 
-def fastest(protocol=None):
+def fastest(protocol=None, min_tier=None):
     """Connect to the fastest server available."""
 
     logger.debug("Starting fastest connect")
@@ -149,7 +149,7 @@ def fastest(protocol=None):
     disconnect(passed=True)
     pull_server_data(force=True)
 
-    servers = get_servers()
+    servers = get_servers(min_tier)
 
     # ProtonVPN Features: 1: SECURE-CORE, 2: TOR, 4: P2P
     excluded_features = [1, 2]
@@ -164,7 +164,7 @@ def fastest(protocol=None):
     openvpn_connect(fastest_server, protocol)
 
 
-def country_f(country_code, protocol=None):
+def country_f(country_code, protocol=None, min_tier=None):
     """Connect to the fastest server in a specific country."""
     logger.debug("Starting fastest country connect")
 
@@ -176,7 +176,7 @@ def country_f(country_code, protocol=None):
     disconnect(passed=True)
     pull_server_data(force=True)
 
-    servers = get_servers()
+    servers = get_servers(min_tier)
 
     # ProtonVPN Features: 1: SECURE-CORE, 2: TOR, 4: P2P
     excluded_features = [1, 2]
@@ -199,7 +199,7 @@ def country_f(country_code, protocol=None):
     openvpn_connect(fastest_server, protocol)
 
 
-def feature_f(feature, protocol=None):
+def feature_f(feature, protocol=None, min_tier=None):
     """Connect to the fastest server in a specific country."""
     logger.debug(
         "Starting fastest feature connect with feature {0}".format(feature)
@@ -211,7 +211,7 @@ def feature_f(feature, protocol=None):
     disconnect(passed=True)
     pull_server_data(force=True)
 
-    servers = get_servers()
+    servers = get_servers(min_tier)
 
     server_pool = [s for s in servers if s["Features"] == feature]
 
@@ -402,6 +402,7 @@ def status():
     country = get_country_name(country_code)
     city = get_server_value(connected_server, "City", servers)
     load = get_server_value(connected_server, "Load", servers)
+    tier = int(get_server_value(connected_server, "Tier", servers))
     feature = get_server_value(connected_server, "Features", servers)
     last_connection = get_config_value("metadata", "connected_time")
     connection_time = time.time() - int(last_connection)
@@ -424,6 +425,7 @@ def status():
         + "Time:         {0}\n".format(connection_time)
         + "IP:           {0}\n".format(ip)
         + "Server:       {0}\n".format(connected_server)
+        + "Tier:         {0}\n".format(tier + 1)  # 1-based UI tier
         + "Features:     {0}\n".format(all_features[feature])
         + "Protocol:     {0}\n".format(connected_protocol.upper())
         + "Kill Switch:  {0}\n".format(killswitch_status)

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -94,7 +94,7 @@ def pull_server_data(force=False):
         logger.debug("last_api_call updated")
 
 
-def get_servers():
+def get_servers(min_tier=None):
     """Return a list of all servers for the users Tier."""
 
     with open(SERVER_INFO_FILE, "r") as f:
@@ -104,9 +104,14 @@ def get_servers():
     servers = server_data["LogicalServers"]
 
     user_tier = int(get_config_value("USER", "tier"))
+    logger.debug("User tier: {0}, minimum tier: {1}".format(
+        user_tier, min_tier))  # log 0-based API tiers
 
-    # Sort server IDs by Tier
-    return [server for server in servers if server["Tier"] <= user_tier and server["Status"] == 1] # noqa
+    # Filter for acceptable tiers and status.
+    return [server for server in servers
+        if (server["Tier"] <= user_tier and # noqa
+            (min_tier is None or server["Tier"] >= min_tier)) and # noqa
+            server["Status"] == 1]
 
 
 def get_server_value(servername, key, servers):


### PR DESCRIPTION
ProtonVPN advertises certain features exclusive to their higher-tier
services (e.g., https://protonvpn.com/support/watch-netflix-with-vpn/),
but how does one actually use such features? Connecting to the "fastest"
server doesn't really work, because this often results in a "Basic"
server. One could manually select the specific server, but this is not
a good UI. The --min_tier option allows one to select the fastest
server, with a tier greater than or equal to --min_tier, providing
that the user's plan is compatible with the given --min_tier.

--min_tier is applied every place it could be relevant: fastest server,
fastest server in a country, random server, and p2p server. There is
currently no possibility of using a lower tier server in combination
with TOR or Secure Core, so it is not applied in combination with those
features.