### PR TITLE
Fix #144: Use pgrep -x instead of --exact

### DIFF
--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -188,7 +188,7 @@ def get_default_nic():
 
 def is_connected():
     """Check if a VPN connection already exists."""
-    ovpn_processes = subprocess.run(["pgrep", "--exact", "openvpn"],
+    ovpn_processes = subprocess.run(["pgrep", "-x", "openvpn"],
                                     stdout=subprocess.PIPE)
     ovpn_processes = ovpn_processes.stdout.decode("utf-8").split()
 


### PR DESCRIPTION
As mentioned in the issue, `--exact` is not available on Alpine. I haven't encountered any system where `--exact` exists but `-x` doesn't, so this should be safe.