### PR TITLE
Update links to reflect repository rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before creating a Pull Request.
 
-Please note we have a [code of conduct](https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](https://github.com/ProtonVPN/linux-cli/blob/master/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 
 By making a contribution to this project you agree to the following:
 
@@ -14,6 +14,6 @@ By making a contribution to this project you agree to the following:
 
 1. Ensure that your code is [Flake8](https://flake8.pycqa.org/en/latest/) compatible. In cases this doesn't work out, use the `# noqa` comment.
 2. Ensure that your code is compatible with the lowest Python Version supported by this project (Currently 3.5)
-3. If applicable, update [DOCUMENTATION.md](https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/DOCUMENTATION.md) and [USAGE.md](https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/USAGE.md) to reflect changes correctly.
+3. If applicable, update [DOCUMENTATION.md](https://github.com/ProtonVPN/linux-cli/blob/master/DOCUMENTATION.md) and [USAGE.md](https://github.com/ProtonVPN/linux-cli/blob/master/USAGE.md) to reflect changes correctly.
 4. If your PR fixes an issue, prefix your commit or the PR title with `Fix #42:` where 42 is the corresponding issue number.
 5. Follow [best practices](https://chris.beams.io/posts/git-commit/) in your commit messages.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
     <a href="https://pepy.tech/project/protonvpn-cli"><img alt="Downloads" src="https://pepy.tech/badge/protonvpn-cli"></a>
-    <img alt="GitHub" src="https://img.shields.io/github/license/ProtonVPN/protonvpn-cli-ng">
+    <img alt="GitHub" src="https://img.shields.io/github/license/ProtonVPN/linux-cli">
     <a href="https://pepy.tech/project/protonvpn-cli/week"><img alt="Downloads per Week" src="https://pepy.tech/badge/protonvpn-cli/week"></a>
     <br>
     <a href="https://twitter.com/ProtonVPN"><img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/ProtonVPN?style=social"></a>
@@ -18,7 +18,7 @@ ProtonVPN-CLI is a full rewrite of the [bash protonvpn-cli](https://github.com/P
 
 ## Installation & Updating
 
-For more detailed information on installing, updating and uninstalling, please view the extensive [usage guide](https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/USAGE.md#installation--updating).
+For more detailed information on installing, updating and uninstalling, please view the extensive [usage guide](https://github.com/ProtonVPN/linux-cli/blob/master/USAGE.md#installation--updating).
 
 ### Installing Dependencies
 
@@ -53,17 +53,17 @@ Installation happens via Python's package manager PIP.
 
 ### Manual Installation from source
 
-*Disclaimer: If you are unsure about what you're doing, please follow the [normal installation guide](https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/USAGE.md#installation--updating).*
+*Disclaimer: If you are unsure about what you're doing, please follow the [normal installation guide](https://github.com/ProtonVPN/linux-cli/blob/master/USAGE.md#installation--updating).*
 
 It is recommended to do the manual installation in a virtual environment. Especially if it serves the purpose of developing.
 
 1. Clone this repository
 
-    `git clone https://github.com/protonvpn/protonvpn-cli-ng`
+    `git clone https://github.com/protonvpn/linux-cli`
 
 2. Step into the directory
 
-   `cd protonvpn-cli-ng`
+   `cd linux-cli`
 
 3. Install
 
@@ -73,7 +73,7 @@ For updating, you just need to pull the latest version of the repository with gi
 
 ### How to use
 
-#### For more detailed information, see the extensive [usage guide](https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/USAGE.md).
+#### For more detailed information, see the extensive [usage guide](https://github.com/ProtonVPN/linux-cli/blob/master/USAGE.md).
 
 | **Command**                       | **Description**                                       |
 |:----------------------------------|:------------------------------------------------------|
@@ -98,4 +98,4 @@ All connect options can be used with the `-p` flag to explicitly specify which t
 
 ## Contributing
 
-If you want to contribute to this project, please read the [contribution guide](https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/CONTRIBUTING.md).
+If you want to contribute to this project, please read the [contribution guide](https://github.com/ProtonVPN/linux-cli/blob/master/CONTRIBUTING.md).

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -414,10 +414,10 @@ def check_update():
                 ) +
             "is available.\n" +
             "Follow the Update instructions on\n" +
-            "https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/USAGE.md#updating-protonvpn-cli\n" + # noqa
+            "https://github.com/ProtonVPN/linux-cli/blob/master/USAGE.md#updating-protonvpn-cli\n" + # noqa
             "\n"
             "To see what's new, check out the changelog:\n" +
-            "https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/CHANGELOG.md" # noqa
+            "https://github.com/ProtonVPN/linux-cli/blob/master/CHANGELOG.md" # noqa
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ The official Linux CLI for ProtonVPN.
 
 For further information and a usage guide, please view the project page:
 
-https://github.com/ProtonVPN/protonvpn-cli-ng
+https://github.com/ProtonVPN/linux-cli
 """
 
 
@@ -33,7 +33,7 @@ setup(
     author="Proton Technologies AG",
     author_email="contact@protonvpn.com",
     license="GPLv3",
-    url="https://github.com/protonvpn/protonvpn-cli-ng",
+    url="https://github.com/protonvpn/linux-cli",
     install_requires=[
         "requests",
         "docopt",


### PR DESCRIPTION
Since the name changed from `protonvpn-cli-ng` to `linux-cli` recently, it makes sense to use the proper links everywhere, even though redirection is in place.