### PR TITLE
Jinja2 Template, IPv6 pull-filters, skip ipv6 leak protection when ipv6 disabled

### DIFF
--- a/protonvpn_cli/cli.py
+++ b/protonvpn_cli/cli.py
@@ -57,9 +57,9 @@ from docopt import docopt
 from . import connection
 from .logger import logger
 from .utils import (
-    check_root, change_file_owner, pull_server_data, make_ovpn_template,
-    check_init, set_config_value, get_config_value, is_valid_ip,
-    wait_for_network
+    check_root, change_file_owner, pull_server_data,
+    check_init, set_config_value, get_config_value,
+    is_valid_ip, wait_for_network
 )
 # Constants
 from .constants import (
@@ -143,7 +143,6 @@ def cli():
         configure_cli()
     elif args.get("refresh"):
         pull_server_data(force=True)
-        make_ovpn_template()
     elif args.get("examples"):
         print_examples()
 
@@ -241,7 +240,6 @@ def init_cli():
         init_config_file()
 
         pull_server_data()
-        make_ovpn_template()
 
         # Change user tier to correct value
         if user_tier == 4:
@@ -655,4 +653,3 @@ def set_split_tunnel():
 
     print()
     print("Split tunneling configuration updated.")
-    make_ovpn_template()

--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -18,11 +18,11 @@ from .utils import (
     get_servers, get_server_value, get_config_value,
     set_config_value, get_ip_info, get_country_name,
     get_fastest_server, check_update, get_default_nic,
-    get_transferred_data
+    get_transferred_data, create_openvpn_config
 )
 # Constants
 from .constants import (
-    CONFIG_DIR, TEMPLATE_FILE, OVPN_FILE, PASSFILE, CONFIG_FILE
+    CONFIG_DIR, OVPN_FILE, PASSFILE, CONFIG_FILE
 )
 
 
@@ -445,19 +445,12 @@ def openvpn_connect(servername, protocol):
 
     port = {"udp": 1194, "tcp": 443}
 
-    shutil.copyfile(TEMPLATE_FILE, OVPN_FILE)
-
     servers = get_servers()
     subservers = get_server_value(servername, "Servers", servers)
     ip_list = [subserver["EntryIP"] for subserver in subservers]
 
-    with open(OVPN_FILE, "a") as f:
-        f.write("\n\n")
-        f.write("proto {0}\n".format(protocol.lower()))
-        for ip in ip_list:
-            f.write("remote {0} {1}\n".format(ip, port[protocol.lower()]))
-        logger.debug("IPs: {0}".format(ip_list))
-        logger.debug("connect.ovpn written")
+    # Ports gets casted to a list instead of just a single port to make it iterable
+    create_openvpn_config(serverlist=ip_list, protocol=protocol, ports=[port[protocol.lower()]])
 
     disconnect(passed=True)
 

--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -18,7 +18,8 @@ from .utils import (
     get_servers, get_server_value, get_config_value,
     set_config_value, get_ip_info, get_country_name,
     get_fastest_server, check_update, get_default_nic,
-    get_transferred_data, create_openvpn_config
+    get_transferred_data, create_openvpn_config,
+    is_ipv6_disabled
 )
 # Constants
 from .constants import (
@@ -648,6 +649,10 @@ def manage_ipv6(mode):
         if os.path.isfile(ip6tables_backupfile):
             logger.debug("IPv6 backup exists")
             manage_ipv6("restore")
+
+        if is_ipv6_disabled():
+            logger.debug("IPv6 is disabled or unavailable, skipping leak protection")
+            return
 
         # Backing up ip6ables rules
         logger.debug("Backing up ip6tables rules")

--- a/protonvpn_cli/constants.py
+++ b/protonvpn_cli/constants.py
@@ -13,7 +13,6 @@ except KeyError:
 
 CONFIG_DIR = os.path.join(os.path.expanduser("~{0}".format(USER)), ".pvpn-cli")
 CONFIG_FILE = os.path.join(CONFIG_DIR, "pvpn-cli.cfg")
-TEMPLATE_FILE = os.path.join(CONFIG_DIR, "template.ovpn")
 SERVER_INFO_FILE = os.path.join(CONFIG_DIR, "serverinfo.json")
 SPLIT_TUNNEL_FILE = os.path.join(CONFIG_DIR, "split_tunnel.txt")
 OVPN_FILE = os.path.join(CONFIG_DIR, "connect.ovpn")

--- a/protonvpn_cli/templates/openvpn_template.j2
+++ b/protonvpn_cli/templates/openvpn_template.j2
@@ -1,0 +1,122 @@
+# ==============================================================================
+# Copyright (c) 2016-2020 Proton Technologies AG (Switzerland)
+# Email: contact@protonvpn.com
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR # OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+
+client
+dev tun
+proto {{ openvpn_protocol }}
+
+{% for ip in serverlist %}
+{%- for port in openvpn_ports -%}
+remote {{ ip }} {{ port }}
+{% endfor %}
+{% endfor -%}
+
+remote-random
+resolv-retry infinite
+nobind
+cipher AES-256-CBC
+auth SHA512
+comp-lzo no
+verb 3
+
+tun-mtu 1500
+tun-mtu-extra 32
+mssfix 1450
+persist-key
+persist-tun
+
+reneg-sec 0
+
+remote-cert-tls server
+auth-user-pass
+pull
+fast-io
+
+{%- if split %}
+
+# Split Tunneling
+{%- for ip_nm_pair in ip_nm_pairs %}
+route {{ ip_nm_pair.ip }} {{ ip_nm_pair.nm }} net_gateway
+{%- endfor %}
+{%- endif %}
+
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFozCCA4ugAwIBAgIBATANBgkqhkiG9w0BAQ0FADBAMQswCQYDVQQGEwJDSDEV
+MBMGA1UEChMMUHJvdG9uVlBOIEFHMRowGAYDVQQDExFQcm90b25WUE4gUm9vdCBD
+QTAeFw0xNzAyMTUxNDM4MDBaFw0yNzAyMTUxNDM4MDBaMEAxCzAJBgNVBAYTAkNI
+MRUwEwYDVQQKEwxQcm90b25WUE4gQUcxGjAYBgNVBAMTEVByb3RvblZQTiBSb290
+IENBMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAt+BsSsZg7+AuqTq7
+vDbPzfygtl9f8fLJqO4amsyOXlI7pquL5IsEZhpWyJIIvYybqS4s1/T7BbvHPLVE
+wlrq8A5DBIXcfuXrBbKoYkmpICGc2u1KYVGOZ9A+PH9z4Tr6OXFfXRnsbZToie8t
+2Xjv/dZDdUDAqeW89I/mXg3k5x08m2nfGCQDm4gCanN1r5MT7ge56z0MkY3FFGCO
+qRwspIEUzu1ZqGSTkG1eQiOYIrdOF5cc7n2APyvBIcfvp/W3cpTOEmEBJ7/14RnX
+nHo0fcx61Inx/6ZxzKkW8BMdGGQF3tF6u2M0FjVN0lLH9S0ul1TgoOS56yEJ34hr
+JSRTqHuar3t/xdCbKFZjyXFZFNsXVvgJu34CNLrHHTGJj9jiUfFnxWQYMo9UNUd4
+a3PPG1HnbG7LAjlvj5JlJ5aqO5gshdnqb9uIQeR2CdzcCJgklwRGCyDT1pm7eoiv
+WV19YBd81vKulLzgPavu3kRRe83yl29It2hwQ9FMs5w6ZV/X6ciTKo3etkX9nBD9
+ZzJPsGQsBUy7CzO1jK4W01+u3ItmQS+1s4xtcFxdFY8o/q1zoqBlxpe5MQIWN6Qa
+lryiET74gMHE/S5WrPlsq/gehxsdgc6GDUXG4dk8vn6OUMa6wb5wRO3VXGEc67IY
+m4mDFTYiPvLaFOxtndlUWuCruKcCAwEAAaOBpzCBpDAMBgNVHRMEBTADAQH/MB0G
+A1UdDgQWBBSDkIaYhLVZTwyLNTetNB2qV0gkVDBoBgNVHSMEYTBfgBSDkIaYhLVZ
+TwyLNTetNB2qV0gkVKFEpEIwQDELMAkGA1UEBhMCQ0gxFTATBgNVBAoTDFByb3Rv
+blZQTiBBRzEaMBgGA1UEAxMRUHJvdG9uVlBOIFJvb3QgQ0GCAQEwCwYDVR0PBAQD
+AgEGMA0GCSqGSIb3DQEBDQUAA4ICAQCYr7LpvnfZXBCxVIVc2ea1fjxQ6vkTj0zM
+htFs3qfeXpMRf+g1NAh4vv1UIwLsczilMt87SjpJ25pZPyS3O+/VlI9ceZMvtGXd
+MGfXhTDp//zRoL1cbzSHee9tQlmEm1tKFxB0wfWd/inGRjZxpJCTQh8oc7CTziHZ
+ufS+Jkfpc4Rasr31fl7mHhJahF1j/ka/OOWmFbiHBNjzmNWPQInJm+0ygFqij5qs
+51OEvubR8yh5Mdq4TNuWhFuTxpqoJ87VKaSOx/Aefca44Etwcj4gHb7LThidw/ky
+zysZiWjyrbfX/31RX7QanKiMk2RDtgZaWi/lMfsl5O+6E2lJ1vo4xv9pW8225B5X
+eAeXHCfjV/vrrCFqeCprNF6a3Tn/LX6VNy3jbeC+167QagBOaoDA01XPOx7Odhsb
+Gd7cJ5VkgyycZgLnT9zrChgwjx59JQosFEG1DsaAgHfpEl/N3YPJh68N7fwN41Cj
+zsk39v6iZdfuet/sP7oiP5/gLmA/CIPNhdIYxaojbLjFPkftVjVPn49RqwqzJJPR
+N8BOyb94yhQ7KO4F3IcLT/y/dsWitY0ZH4lCnAVV/v2YjWAWS3OWyC8BFx/Jmc3W
+DK/yPwECUcPgHIeXiRjHnJt0Zcm23O2Q3RphpU+1SO3XixsXpOVOYP6rJIXW9bMZ
+A1gTTlpi7A==
+-----END CERTIFICATE-----
+</ca>
+
+key-direction 1
+<tls-auth>
+# 2048 bit OpenVPN static key
+-----BEGIN OpenVPN Static key V1-----
+6acef03f62675b4b1bbd03e53b187727
+423cea742242106cb2916a8a4c829756
+3d22c7e5cef430b1103c6f66eb1fc5b3
+75a672f158e2e2e936c3faa48b035a6d
+e17beaac23b5f03b10b868d53d03521d
+8ba115059da777a60cbfd7b2c9c57472
+78a15b8f6e68a3ef7fd583ec9f398c8b
+d4735dab40cbd1e3c62a822e97489186
+c30a0b48c7c38ea32ceb056d3fa5a710
+e10ccc7a0ddb363b08c3d2777a3395e1
+0c0b6080f56309192ab5aacd4b45f55d
+a61fc77af39bd81a19218a79762c3386
+2df55785075f37d8c71dc8a42097ee43
+344739a0dd48d03025b0450cf1fb5e8c
+aeb893d9a96d1f15519bb3c4dcb40ee3
+16672ea16c012664f8a9f11255518deb
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/protonvpn_cli/templates/openvpn_template.j2
+++ b/protonvpn_cli/templates/openvpn_template.j2
@@ -54,6 +54,13 @@ auth-user-pass
 pull
 fast-io
 
+{%- if ipv6_disabled %}
+
+# Remove IPv6 related configurations
+pull-filter ignore "ifconfig-ipv6"
+pull-filter ignore "route-ipv6"
+{%- endif %}
+
 {%- if split %}
 
 # Split Tunneling

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 docopt
 requests
 pythondialog
+jinja2

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,14 @@ setup(
     author_email="contact@protonvpn.com",
     license="GPLv3",
     url="https://github.com/protonvpn/linux-cli",
+    package_data={
+        "protonvpn_cli": ["templates/*"]
+    },
     install_requires=[
         "requests",
         "docopt",
         "pythondialog",
+        "jinja2",
     ],
     python_requires=">=3.5",
     classifiers=[


### PR DESCRIPTION
This PR does multiple things, as one change is needed for the other.

- Use a Jinja2 template for OpenVPN configuration instead of modifying the config the API provides
- Add IPv6 pull filters to the config when IPv6 is disabled or unavailable system wide
- Don't activate IPv6 leak protection when IPv6 is disabled or unavailable system wide