### PR TITLE
Added support for PolKit

### DIFF
--- a/protonvpn_cli/constants.py
+++ b/protonvpn_cli/constants.py
@@ -1,10 +1,14 @@
 import os
 import getpass
+import pwd
 
 try:
-    USER = os.environ["SUDO_USER"]
+    USER = pwd.getpwuid(int(os.environ["PKEXEC_UID"])).pw_name
 except KeyError:
-    USER = getpass.getuser()
+    try:
+        USER = os.environ["SUDO_USER"]
+    except KeyError:
+        USER = getpass.getuser()
 
 CONFIG_DIR = os.path.join(os.path.expanduser("~{0}".format(USER)), ".pvpn-cli")
 CONFIG_FILE = os.path.join(CONFIG_DIR, "pvpn-cli.cfg")

--- a/protonvpn_cli/constants.py
+++ b/protonvpn_cli/constants.py
@@ -2,6 +2,7 @@ import os
 import getpass
 import pwd
 
+# This implementation is mostly for GUI support. See #168
 try:
     USER = pwd.getpwuid(int(os.environ["PKEXEC_UID"])).pw_name
 except KeyError:


### PR DESCRIPTION
- Added support for policy kit
- If the CLI is launched via a .desktop launcher (or without a terminal) and with pkexec instead of sudo, then a prompt window is displayed for the user to input the sudo password.
- If no pkexec is found, then it fallback to the default sudo implementation.
- This implementation is mostly for GUI support. Solves [#54](https://github.com/ProtonVPN/linux-gui/issues/54), [#34](https://github.com/ProtonVPN/linux-gui/issues/34), (partially) [#55](https://github.com/ProtonVPN/linux-gui/issues/55) and perhaps even [#44](https://github.com/ProtonVPN/linux-gui/issues/44)