### PR TITLE
Fix #181: Make protocol lower case in j2 template

### DIFF
--- a/protonvpn_cli/templates/openvpn_template.j2
+++ b/protonvpn_cli/templates/openvpn_template.j2
@@ -25,7 +25,7 @@
 
 client
 dev tun
-proto {{ openvpn_protocol }}
+proto {{ openvpn_protocol|lower }}
 
 {% for ip in serverlist %}
 {%- for port in openvpn_ports -%}


### PR DESCRIPTION
Unfortunately I missed that the protocol supplied by the dialog menu is upper case, making it incompatible with the openvpn config file. This fix makes sure that any protocol written to `connect.ovpn` is lower case.