### PR TITLE
Make OpenVPN protocol lowercase.

### DIFF
--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -451,7 +451,7 @@ def openvpn_connect(servername, protocol):
     ip_list = [subserver["EntryIP"] for subserver in subservers]
 
     # Ports gets casted to a list instead of just a single port to make it iterable
-    create_openvpn_config(serverlist=ip_list, protocol=protocol, ports=[port[protocol.lower()]])
+    create_openvpn_config(serverlist=ip_list, protocol=protocol.lower(), ports=[port[protocol.lower()]])
 
     disconnect(passed=True)
 


### PR DESCRIPTION
Hi
The protocol string written to connect.ovpn should be lowercase. OpenVPN doesn't accept uppercase and as a result hasn't been connecting for me for the past several days. This change fixes the problem.
All the best,
Ivan