### PR TITLE
Fix #18: Allow connecting only to Plus servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ For updating, you just need to pull the latest version of the repository with gi
 
 All connect options can be used with the `-p` flag to explicitly specify which transmission protocol is used for that connection (either `udp` or `tcp`).
 
+The `--plus` flag can be used with `-r | --random`, `-f | --fastest`, and `-cc` to pick only from Plus servers, if the user's plan is compatible.
+
 ## Contributing
 
 If you want to contribute to this project, please read the [contribution guide](https://github.com/ProtonVPN/linux-cli/blob/master/CONTRIBUTING.md).

--- a/USAGE.md
+++ b/USAGE.md
@@ -253,6 +253,8 @@ Before you can use ProtonVPN-CLI, you need to initialize it. Run `sudo protonvpn
 
 All connect options can be used with the `-p` flag to explicitly specify which transmission protocol is used for that connection (either `udp` or `tcp`).
 
+The `--plus` flag can be used with `-r | --random`, `-f | --fastest`, and `-cc` to pick only from Plus servers, if the user's plan is compatible.
+
 ### Command Explanations
 
 You can see the full list of commands by running `protonvpn --help` and a list of examples by running `protonvpn examples`.
@@ -316,6 +318,28 @@ Connect to the fastest server with TCP:
 Connect to a random server with UDP:
 
 `protonvpn c -rp UDP`
+
+To connect to a Plus server when connecting to the fastest server, fastest server in a specific country, or a random server, use the `--plus` flag:
+
+To connect to the fastest Plus server:
+
+`protonvpn c -f --plus`
+
+To connect to the fastest Plus server with TCP:
+
+`protonvpn c -f -p TCP --plus`
+
+To connect to the fastest Plus server in a country (replace UK with the code of the desired country, e.g. `US` for USA, `JP` for Japan, `AU` for Australia, etc.):
+
+`protonvpn c --cc UK --plus`
+
+To connect to a random Plus server:
+
+`protonvpn c -r --plus`
+
+To connect to a random Plus server with UDP:
+
+`protonvpn c -rp UDP --plus`
 
 To disconnect the VPN, you need to use the `disconnect` or `d` option:
 

--- a/protonvpn_cli/cli.py
+++ b/protonvpn_cli/cli.py
@@ -4,12 +4,12 @@ A CLI for ProtonVPN.
 Usage:
     protonvpn init
     protonvpn (c | connect) [<servername>] [-p <protocol>]
-    protonvpn (c | connect) [-f | --fastest] [-p <protocol>]
-    protonvpn (c | connect) [--cc <code>] [-p <protocol>]
+    protonvpn (c | connect) [-f | --fastest] [-p <protocol>] [--plus]
+    protonvpn (c | connect) [--cc <code>] [-p <protocol>] [--plus]
     protonvpn (c | connect) [--sc] [-p <protocol>]
     protonvpn (c | connect) [--p2p] [-p <protocol>]
     protonvpn (c | connect) [--tor] [-p <protocol>]
-    protonvpn (c | connect) [-r | --random] [-p <protocol>]
+    protonvpn (c | connect) [-r | --random] [-p <protocol>] [--plus]
     protonvpn (r | reconnect)
     protonvpn (d | disconnect)
     protonvpn (s | status)
@@ -26,6 +26,7 @@ Options:
     --sc                Connect to the fastest Secure-Core server.
     --p2p               Connect to the fastest torrent server.
     --tor               Connect to the fastest Tor server.
+    --plus              Connect to a Plus-tiered server, if compatible with the user's plan
     -p PROTOCOL         Determine the protocol (UDP or TCP).
     -h, --help          Show this help message.
     -v, --version       Display version.
@@ -110,14 +111,16 @@ def cli():
         if protocol is not None and protocol.lower().strip() in ["tcp", "udp"]:
             protocol = protocol.lower().strip()
 
+        force_plus_server = args.get("--plus")
+
         if args.get("--random"):
-            connection.random_c(protocol)
+            connection.random_c(protocol, force_plus_server)
         elif args.get("--fastest"):
-            connection.fastest(protocol)
+            connection.fastest(protocol, force_plus_server)
         elif args.get("<servername>"):
             connection.direct(args.get("<servername>"), protocol)
         elif args.get("--cc") is not None:
-            connection.country_f(args.get("--cc"), protocol)
+            connection.country_f(args.get("--cc"), protocol, force_plus_server)
         # Features: 1: Secure-Core, 2: Tor, 4: P2P
         elif args.get("--p2p"):
             connection.feature_f(4, protocol)

--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -124,7 +124,7 @@ def dialog():
     openvpn_connect(server_result, protocol_result)
 
 
-def random_c(protocol=None):
+def random_c(protocol=None, force_plus_server=None):
     """Connect to a random ProtonVPN Server."""
 
     logger.debug("Starting random connect")
@@ -132,14 +132,14 @@ def random_c(protocol=None):
     if not protocol:
         protocol = get_config_value("USER", "default_protocol")
 
-    servers = get_servers()
+    servers = get_servers(force_plus_server)
 
     servername = random.choice(servers)["Name"]
 
     openvpn_connect(servername, protocol)
 
 
-def fastest(protocol=None):
+def fastest(protocol=None, force_plus_server=None):
     """Connect to the fastest server available."""
 
     logger.debug("Starting fastest connect")
@@ -150,7 +150,7 @@ def fastest(protocol=None):
     disconnect(passed=True)
     pull_server_data(force=True)
 
-    servers = get_servers()
+    servers = get_servers(force_plus_server)
 
     # ProtonVPN Features: 1: SECURE-CORE, 2: TOR, 4: P2P
     excluded_features = [1, 2]
@@ -165,7 +165,7 @@ def fastest(protocol=None):
     openvpn_connect(fastest_server, protocol)
 
 
-def country_f(country_code, protocol=None):
+def country_f(country_code, protocol=None, force_plus_server=None):
     """Connect to the fastest server in a specific country."""
     logger.debug("Starting fastest country connect")
 
@@ -177,7 +177,7 @@ def country_f(country_code, protocol=None):
     disconnect(passed=True)
     pull_server_data(force=True)
 
-    servers = get_servers()
+    servers = get_servers(force_plus_server)
 
     # ProtonVPN Features: 1: SECURE-CORE, 2: TOR, 4: P2P
     excluded_features = [1, 2]

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -110,7 +110,7 @@ def get_servers(force_plus_server=None):
     return [
         server for server in servers
         if server["Tier"] <= user_tier
-        and (force_plus_server is None or (user_tier >= 2 and server["Tier"] == 2) or True)
+        and (force_plus_server is None or (user_tier >= 2 and server["Tier"] == 2) or (force_plus_server is None and True))
         and server["Status"] == 1
     ]
 

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -94,7 +94,7 @@ def pull_server_data(force=False):
         logger.debug("last_api_call updated")
 
 
-def get_servers():
+def get_servers(force_plus_server=None):
     """Return a list of all servers for the users Tier."""
 
     with open(SERVER_INFO_FILE, "r") as f:
@@ -105,8 +105,14 @@ def get_servers():
 
     user_tier = int(get_config_value("USER", "tier"))
 
-    # Sort server IDs by Tier
-    return [server for server in servers if server["Tier"] <= user_tier and server["Status"] == 1] # noqa
+    # Sort server IDs by Tier and filter only Plus servers if specified and
+    # the user's plan allows it
+    return [
+        server for server in servers
+        if server["Tier"] <= user_tier
+        and (force_plus_server is None or (user_tier >= 2 and server["Tier"] == 2) or True)
+        and server["Status"] == 1
+    ]
 
 
 def get_server_value(servername, key, servers):

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -110,7 +110,10 @@ def get_servers(force_plus_server=None):
     return [
         server for server in servers
         if server["Tier"] <= user_tier
-        and (force_plus_server is None or (user_tier >= 2 and server["Tier"] == 2) or (force_plus_server is None and True))
+        and (
+            force_plus_server is None or (user_tier >= 2 and server["Tier"] == 2)
+            or (force_plus_server is None and True)
+        )
         and server["Status"] == 1
     ]
 


### PR DESCRIPTION
Implements passing the --plus flag to specific commands to pick only Plus servers if the user's plan allows it.

Fixes #18.