### PR TITLE
Support for the client to declare itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v2.2.5](#v225)
 - [v2.2.4](#v224)
 - [v2.2.3](#v223)
 - [v2.2.2](#v222)
@@ -12,6 +13,10 @@
 - [v2.1.0](#v210)
 - [v2.0.0](#v200)
 - [v0.1.0](#v010)
+
+## v2.2.5
+
+- Enhancement: Introduces support for the client to declare itself
 
 ## v2.2.4
 

--- a/protonvpn_cli/cli.py
+++ b/protonvpn_cli/cli.py
@@ -63,7 +63,7 @@ from .utils import (
 )
 # Constants
 from .constants import (
-    CONFIG_DIR, CONFIG_FILE, PASSFILE, USER, VERSION, SPLIT_TUNNEL_FILE
+    CONFIG_DIR, CONFIG_FILE, PASSFILE, USER, VERSION, SPLIT_TUNNEL_FILE, CLIENT_SUFFIX
 )
 
 
@@ -256,7 +256,7 @@ def init_cli():
         set_config_value("USER", "killswitch", 0)
 
         with open(PASSFILE, "w") as f:
-            f.write("{0}\n{1}".format(ovpn_username, ovpn_password))
+            f.write("{0}+{1}\n{2}".format(ovpn_username, CLIENT_SUFFIX, ovpn_password))
             logger.debug("Passfile created")
             os.chmod(PASSFILE, 0o600)
 

--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -19,11 +19,11 @@ from .utils import (
     set_config_value, get_ip_info, get_country_name,
     get_fastest_server, check_update, get_default_nic,
     get_transferred_data, create_openvpn_config,
-    is_ipv6_disabled
+    is_ipv6_disabled, patch_passfile
 )
 # Constants
 from .constants import (
-    CONFIG_DIR, OVPN_FILE, PASSFILE, CONFIG_FILE
+    CONFIG_DIR, OVPN_FILE, PASSFILE, CONFIG_FILE, CLIENT_SUFFIX
 )
 
 
@@ -458,6 +458,8 @@ def openvpn_connect(servername, protocol):
     old_ip, _ = get_ip_info()
 
     print("Connecting to {0} via {1}...".format(servername, protocol.upper()))
+
+    patch_passfile(PASSFILE)
 
     with open(os.path.join(CONFIG_DIR, "ovpn.log"), "w+") as f:
         subprocess.Popen(

--- a/protonvpn_cli/constants.py
+++ b/protonvpn_cli/constants.py
@@ -17,4 +17,5 @@ SERVER_INFO_FILE = os.path.join(CONFIG_DIR, "serverinfo.json")
 SPLIT_TUNNEL_FILE = os.path.join(CONFIG_DIR, "split_tunnel.txt")
 OVPN_FILE = os.path.join(CONFIG_DIR, "connect.ovpn")
 PASSFILE = os.path.join(CONFIG_DIR, "pvpnpass")
-VERSION = "2.2.4"
+CLIENT_SUFFIX = "plc" # ProtonVPN Linux Community
+VERSION = "2.2.5"

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -17,7 +17,7 @@ from .logger import logger
 # Constants
 from .constants import (
     USER, CONFIG_FILE, SERVER_INFO_FILE, SPLIT_TUNNEL_FILE,
-    VERSION, OVPN_FILE
+    VERSION, OVPN_FILE, CLIENT_SUFFIX
 )
 
 
@@ -521,3 +521,14 @@ def get_transferred_data():
         rx_bytes = int(f.read())
 
     return convert_size(tx_bytes), convert_size(rx_bytes)
+
+
+def patch_passfile(passfile):
+    with open(passfile, "r") as f:
+        ovpn_username = f.readline()
+        ovpn_password = f.readline()
+    if CLIENT_SUFFIX not in ovpn_username.strip().split('+')[1:]:
+        # Let's append the CLIENT_SUFFIX
+        with open(passfile, "w") as f:
+            f.write("{0}+{1}\n{2}".format(ovpn_username.strip(), CLIENT_SUFFIX, ovpn_password))
+        os.chmod(passfile, 0o600)


### PR DESCRIPTION
* Introduces support for the client to declare itself as ProtonVPN Linux
  Community client.

Signed-off-by: Samuele Kaplun <kaplun@protonmail.com>