### PR TITLE
Client versioning in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v2.2.6](#v226)
 - [v2.2.5](#v225)
 - [v2.2.4](#v224)
 - [v2.2.3](#v223)
@@ -13,6 +14,10 @@
 - [v2.1.0](#v210)
 - [v2.0.0](#v200)
 - [v0.1.0](#v010)
+
+## v2.2.6
+
+- Enhancement: Properly specifies versioning when contacting Proton API
 
 ## v2.2.5
 

--- a/protonvpn_cli/connection.py
+++ b/protonvpn_cli/connection.py
@@ -23,7 +23,7 @@ from .utils import (
 )
 # Constants
 from .constants import (
-    CONFIG_DIR, OVPN_FILE, PASSFILE, CONFIG_FILE, CLIENT_SUFFIX
+    CONFIG_DIR, OVPN_FILE, PASSFILE, CONFIG_FILE
 )
 
 

--- a/protonvpn_cli/constants.py
+++ b/protonvpn_cli/constants.py
@@ -17,5 +17,5 @@ SERVER_INFO_FILE = os.path.join(CONFIG_DIR, "serverinfo.json")
 SPLIT_TUNNEL_FILE = os.path.join(CONFIG_DIR, "split_tunnel.txt")
 OVPN_FILE = os.path.join(CONFIG_DIR, "connect.ovpn")
 PASSFILE = os.path.join(CONFIG_DIR, "pvpnpass")
-CLIENT_SUFFIX = "plc" # ProtonVPN Linux Community
-VERSION = "2.2.5"
+CLIENT_SUFFIX = "plc"  # ProtonVPN Linux Community
+VERSION = "2.2.6"

--- a/protonvpn_cli/utils.py
+++ b/protonvpn_cli/utils.py
@@ -28,7 +28,7 @@ def call_api(endpoint, json_format=True, handle_errors=True):
     url = api_domain + endpoint
 
     headers = {
-        "x-pm-appversion": "Other",
+        "x-pm-appversion": "LinuxVPN_{0}".format(VERSION),
         "x-pm-apiversion": "3",
         "Accept": "application/vnd.protonmail.v1+json"
     }


### PR DESCRIPTION
* Properly declares the client versioning when contacting the Proton
  API.

Signed-off-by: Samuele Kaplun <kaplun@protonmail.com>