### PR TITLE
Add required dependency on Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Depending on your distribution, run the appropriate following command to install
 |Fedora/CentOS/RHEL                       | `sudo dnf install -y openvpn dialog python3-pip python3-setuptools`|
 |Ubuntu/Linux Mint/Debian and derivatives | `sudo apt install -y openvpn dialog python3-pip python3-setuptools`|
 |OpenSUSE/SLES                            | `sudo zypper in -y openvpn dialog python3-pip python3-setuptools`  |
-|Arch Linux/Manjaro                       | `sudo pacman -S openvpn dialog python-pip python-setuptools`       |
+|Arch Linux/Manjaro                       | `sudo pacman -S which openvpn dialog python-pip python-setuptools`       |
 
 #### Installing ProtonVPN-CLI
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -84,7 +84,7 @@ Depending on your distribution, run the appropriate following command to install
 |Fedora/CentOS/RHEL                       | `sudo dnf install -y openvpn dialog python3-pip python3-setuptools`|
 |Ubuntu/Linux Mint/Debian and derivatives | `sudo apt install -y openvpn dialog python3-pip python3-setuptools`|
 |OpenSUSE/SLES                            | `sudo zypper in -y openvpn dialog python3-pip python3-setuptools`  |
-|Arch Linux/Manjaro                       | `sudo pacman -S openvpn dialog python-pip python-setuptools`       |
+|Arch Linux/Manjaro                       | `sudo pacman -S which openvpn dialog python-pip python-setuptools`       |
 
 #### Installing ProtonVPN-CLI
 


### PR DESCRIPTION
Admittely, the share of users having `which` installed is likely quite high, however on my fresh Arch install I encountered an error due to `which` missing in [line 341 of utils.py](https://github.com/ProtonVPN/linux-cli/blob/master/protonvpn_cli/utils.py#L341).